### PR TITLE
Rename `Loading` state to `Saving` in `EditableViewState`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ fun MyScreen(viewModel: MyViewModel = viewModel()) {
         }
     }
 }
-}
 ```
 
 EditableViewState provides a clear and structured way to manage the state of data that can be edited
@@ -102,7 +101,7 @@ class ProfileViewModel : ViewModel() {
 
             val targetProfile = UserProfile(newName)
             _state.value =
-                EditableViewState.Loading(current = currentUserProfile, target = targetProfile)
+                EditableViewState.Saving(current = currentUserProfile, target = targetProfile)
 
             try {
                 // Simulate a network call or save operation
@@ -157,7 +156,7 @@ fun ProfileEditScreen(viewModel: ProfileViewModel = viewModel()) {
 
         val currentDisplayName = when (val state = viewModelState) {
             is EditableViewState.Initial -> state.value.displayName
-            is EditableViewState.Loading -> "Updating to: ${state.target.displayName}..."
+            is EditableViewState.Saving -> "Updating to: ${state.target.displayName}..."
             is EditableViewState.Success -> state.succeeded.displayName
             is EditableViewState.Failure -> "Failed to update to: ${state.failed.displayName} (was: ${state.current.displayName})"
         }
@@ -171,13 +170,13 @@ fun ProfileEditScreen(viewModel: ProfileViewModel = viewModel()) {
             isError = viewModelState.isFailure()
         )
 
-        val isLoading = viewModelState.isLoading()
+        val isSaving = viewModelState.isSaving()
 
         Button(
             onClick = { viewModel.updateDisplayName(editingName) },
-            enabled = !isLoading && editingName.isNotBlank()
+            enabled = !isSaving && editingName.isNotBlank()
         ) {
-            if (isLoading) {
+            if (isSaving) {
                 CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
                 Spacer(Modifier.width(8.dp))
                 Text("Saving...")
@@ -439,12 +438,12 @@ Represents the initial state of the view, before any changes have been made.
 val initialState = EditableViewState.Initial(Unit)
 ```
 
-#### `Loading(Value, Value)`
+#### `Saving(Value, Value)`
 
-Represents the loading state of the view, indicating that data is currently being edited.
+Represents the saving state of the view, indicating that data is currently being edited.
 
 ```kotlin
-val loadingState = EditableViewState.Loading(current = Unit, target = Unit)
+val savingState = EditableViewState.Saving(current = Unit, target = Unit)
 ```
 
 #### `Success(Value, Value)`
@@ -473,13 +472,13 @@ val state = EditableViewState.Initial(Unit)
 state.isInitial() // Output: true
 ```
 
-#### `isLoading()`
+#### `isSaving()`
 
-Checks if the current state is `EditableViewState.Loading`.
+Checks if the current state is `EditableViewState.Saving`.
 
 ```kotlin
-val state = EditableViewState.Loading(current = Unit, target = Unit)
-state.isLoading() // Output: true
+val state = EditableViewState.Saving(current = Unit, target = Unit)
+state.isSaving() // Output: true
 ```
 
 #### `isSuccess()`
@@ -509,13 +508,13 @@ val state = EditableViewState.Initial(Unit)
 state.onInitial { println("Initial state reached") } // Output: Initial state reached
 ```
 
-#### `onLoading(block: (Value, Value) -> Unit)`
+#### `onSaving(block: (Value, Value) -> Unit)`
 
-Executes the given `block` if the current state is `EditableViewState.Loading`.
+Executes the given `block` if the current state is `EditableViewState.Saving`.
 
 ```kotlin
-val state = EditableViewState.Loading(current = Unit, target = Unit)
-state.onLoading { current, target -> println("Loading state reached") } // Output: Loading state reached
+val state = EditableViewState.Saving(current = Unit, target = Unit)
+state.onSaving { current, target -> println("Saving state reached") } // Output: Saving state reached
 ```
 
 #### `onSuccess(block: (Value, Value) -> Unit)`
@@ -546,7 +545,7 @@ state.relevantValue() // Output: initial
 ```
 
 ```kotlin
-val state = EditableViewState.Loading(current = "current", target = "target")
+val state = EditableViewState.Saving(current = "current", target = "target")
 state.relevantValue() // Output: current
 ```
 

--- a/viewing-state/src/main/java/com/felipearpa/ui/state/EditableViewState.kt
+++ b/viewing-state/src/main/java/com/felipearpa/ui/state/EditableViewState.kt
@@ -18,13 +18,13 @@ sealed class EditableViewState<out Value : Any> {
     data class Initial<Value : Any>(val value: Value) : EditableViewState<Value>()
 
     /**
-     * Represents the loading state of the view, indicating that data is currently being edited.
+     * Represents the saving state of the view, indicating that data is currently being edited.
      *
      * @param Value The type of data that the view edits.
      * @property current The current data value.
      * @property target The target data value to be edited.
      */
-    data class Loading<Value : Any>(val current: Value, val target: Value) :
+    data class Saving<Value : Any>(val current: Value, val target: Value) :
         EditableViewState<Value>()
 
     /**
@@ -47,7 +47,7 @@ sealed class EditableViewState<out Value : Any> {
     data class Failure<Value : Any>(
         val current: Value,
         val failed: Value,
-        val exception: Throwable
+        val exception: Throwable,
     ) : EditableViewState<Value>()
 }
 
@@ -67,18 +67,18 @@ fun <Value : Any> EditableViewState<Value>.isInitial(): Boolean {
 }
 
 /**
- * Checks if the current state is [EditableViewState.Loading].
+ * Checks if the current state is [EditableViewState.Saving].
  *
  * @param Value The type of data that the view edits.
- * @return `true` if the state is [EditableViewState.Loading], `false` otherwise.
+ * @return `true` if the state is [EditableViewState.Saving], `false` otherwise.
  */
 @OptIn(ExperimentalContracts::class)
-fun <Value : Any> EditableViewState<Value>.isLoading(): Boolean {
+fun <Value : Any> EditableViewState<Value>.isSaving(): Boolean {
     contract {
-        returns(true) implies (this@isLoading is EditableViewState.Loading)
+        returns(true) implies (this@isSaving is EditableViewState.Saving)
     }
 
-    return this is EditableViewState.Loading
+    return this is EditableViewState.Saving
 }
 
 /**
@@ -126,14 +126,14 @@ fun <Value : Any> EditableViewState<Value>.onInitial(block: (value: Value) -> Un
 }
 
 /**
- * Executes the given [block] if the current state is [EditableViewState.Loading].
+ * Executes the given [block] if the current state is [EditableViewState.Saving].
  *
  * @param Value The type of data that the view edits.
  * @param block The block of code to execute.
  * @return The original [EditableViewState] instance.
  */
-fun <Value : Any> EditableViewState<Value>.onLoading(block: (current: Value, target: Value) -> Unit): EditableViewState<Value> {
-    if (this.isLoading()) {
+fun <Value : Any> EditableViewState<Value>.onSaving(block: (current: Value, target: Value) -> Unit): EditableViewState<Value> {
+    if (this.isSaving()) {
         block(this.current, this.target)
     }
     return this
@@ -189,7 +189,7 @@ fun <Value : Any> EditableViewState<Value>.exceptionOrNull(): Throwable? {
 fun <Value : Any> EditableViewState<Value>.relevantValue() =
     when (this) {
         is EditableViewState.Initial -> this.value
-        is EditableViewState.Loading -> this.current
+        is EditableViewState.Saving -> this.current
         is EditableViewState.Success -> this.succeeded
         is EditableViewState.Failure -> this.current
     }

--- a/viewing-state/src/test/java/com/felipearpa/ui/state/EditableViewStateTest.kt
+++ b/viewing-state/src/test/java/com/felipearpa/ui/state/EditableViewStateTest.kt
@@ -23,13 +23,13 @@ class EditableViewStateTest {
     @TestFactory
     fun `given a not initial state when checked if initial then initial is not confirmed`() =
         listOf(
-            EditableViewState.Loading(current = Unit, target = Unit),
+            EditableViewState.Saving(current = Unit, target = Unit),
             EditableViewState.Failure(
                 current = Unit,
                 failed = Unit,
-                exception = RuntimeException()
+                exception = RuntimeException(),
             ),
-            EditableViewState.Success(old = Unit, succeeded = Unit)
+            EditableViewState.Success(old = Unit, succeeded = Unit),
         ).map { viewState ->
             dynamicTest("given a state of $viewState when checked if initial then initial is not confirmed") {
                 val isInitial = viewState.isInitial()
@@ -38,25 +38,25 @@ class EditableViewStateTest {
         }
 
     @Test
-    fun `given a loading state when checked if loading then loading is confirmed`() {
-        val viewState = EditableViewState.Loading(current = Unit, target = Unit)
-        val isLoading = viewState.isLoading()
+    fun `given a saving state when checked if loading then loading is confirmed`() {
+        val viewState = EditableViewState.Saving(current = Unit, target = Unit)
+        val isLoading = viewState.isSaving()
         isLoading.shouldBeTrue()
     }
 
     @TestFactory
-    fun `given a not loading state when checked if loading then loading is not confirmed`() =
+    fun `given a not saving state when checked if loading then loading is not confirmed`() =
         listOf(
             EditableViewState.Initial(Unit),
             EditableViewState.Failure(
                 current = Unit,
                 failed = Unit,
-                exception = RuntimeException()
+                exception = RuntimeException(),
             ),
-            EditableViewState.Success(old = Unit, succeeded = Unit)
+            EditableViewState.Success(old = Unit, succeeded = Unit),
         ).map { viewState ->
             dynamicTest("given a state of $viewState when checked if loading then loading is not confirmed") {
-                val isLoading = viewState.isLoading()
+                val isLoading = viewState.isSaving()
                 isLoading.shouldBeFalse()
             }
         }
@@ -72,12 +72,12 @@ class EditableViewStateTest {
     fun `given a not success state when checked if success then success is not confirmed`() =
         listOf(
             EditableViewState.Initial(Unit),
-            EditableViewState.Loading(current = Unit, target = Unit),
+            EditableViewState.Saving(current = Unit, target = Unit),
             EditableViewState.Failure(
                 current = Unit,
                 failed = Unit,
-                exception = RuntimeException()
-            )
+                exception = RuntimeException(),
+            ),
         ).map { viewState ->
             dynamicTest("given a state of $viewState when checked if success then success is not confirmed") {
                 val isSuccess = viewState.isSuccess()
@@ -90,7 +90,7 @@ class EditableViewStateTest {
         val viewState = EditableViewState.Failure(
             current = Unit,
             failed = Unit,
-            exception = RuntimeException()
+            exception = RuntimeException(),
         )
         val isFailure = viewState.isFailure()
         isFailure.shouldBeTrue()
@@ -100,8 +100,8 @@ class EditableViewStateTest {
     fun `given a not failure state when checked if failure then failure is not confirmed`() =
         listOf(
             EditableViewState.Initial(Unit),
-            EditableViewState.Loading(current = Unit, target = Unit),
-            EditableViewState.Success(old = Unit, succeeded = Unit)
+            EditableViewState.Saving(current = Unit, target = Unit),
+            EditableViewState.Success(old = Unit, succeeded = Unit),
         ).map { viewState ->
             dynamicTest("given a state of $viewState when checked if failure then failure is not confirmed") {
                 val isFailure = viewState.isFailure()
@@ -120,13 +120,13 @@ class EditableViewStateTest {
     }
 
     @Test
-    fun `given a loading state when checked with isLoading then state is smart cast to Loading`() {
+    fun `given a saving state when checked with isLoading then state is smart cast to Loading`() {
         val state: EditableViewState<Unit> =
-            EditableViewState.Loading(current = Unit, target = Unit)
-        if (state.isLoading()) {
+            EditableViewState.Saving(current = Unit, target = Unit)
+        if (state.isSaving()) {
             // If it compiles, the contract is working correctly
-            val castedState: EditableViewState.Loading<Unit> = state
-            castedState.shouldBeInstanceOf<EditableViewState.Loading<Unit>>()
+            val castedState: EditableViewState.Saving<Unit> = state
+            castedState.shouldBeInstanceOf<EditableViewState.Saving<Unit>>()
         }
     }
 
@@ -145,7 +145,7 @@ class EditableViewStateTest {
         val state: EditableViewState<Unit> = EditableViewState.Failure(
             current = Unit,
             failed = Unit,
-            exception = RuntimeException()
+            exception = RuntimeException(),
         )
         if (state.isFailure()) {
             // If it compiles, the contract is working correctly
@@ -159,7 +159,7 @@ class EditableViewStateTest {
         val viewState = EditableViewState.Failure(
             current = Unit,
             failed = Unit,
-            exception = RuntimeException()
+            exception = RuntimeException(),
         )
         val exception = viewState.exceptionOrNull()
         exception.shouldBeInstanceOf<RuntimeException>()
@@ -169,8 +169,8 @@ class EditableViewStateTest {
     fun `given a no failure when checked for exception then the exception is not found`() =
         listOf(
             EditableViewState.Initial(Unit),
-            EditableViewState.Loading(current = Unit, target = Unit),
-            EditableViewState.Success(old = Unit, succeeded = Unit)
+            EditableViewState.Saving(current = Unit, target = Unit),
+            EditableViewState.Success(old = Unit, succeeded = Unit),
         ).map { viewState ->
             dynamicTest("given a $viewState when checked for exception then the exception is not found") {
                 val exception = viewState.exceptionOrNull()
@@ -186,8 +186,8 @@ class EditableViewStateTest {
     }
 
     @Test
-    fun `given a loading state when checked for value then the current value is found`() {
-        val viewState = EditableViewState.Loading(current = "current", target = "target")
+    fun `given a saving state when checked for value then the current value is found`() {
+        val viewState = EditableViewState.Saving(current = "current", target = "target")
         val value = viewState.relevantValue()
         value.shouldBe("current")
     }
@@ -204,7 +204,7 @@ class EditableViewStateTest {
         val viewState = EditableViewState.Failure(
             current = "current",
             failed = "failed",
-            exception = RuntimeException()
+            exception = RuntimeException(),
         )
         val value = viewState.relevantValue()
         value.shouldBe("current")
@@ -222,13 +222,13 @@ class EditableViewStateTest {
     @TestFactory
     fun `given a not initial state when reaction to initial then the action does not run`() =
         listOf(
-            EditableViewState.Loading(current = Unit, target = Unit),
+            EditableViewState.Saving(current = Unit, target = Unit),
             EditableViewState.Failure(
                 current = Unit,
                 failed = Unit,
-                exception = RuntimeException()
+                exception = RuntimeException(),
             ),
-            EditableViewState.Success(old = Unit, succeeded = Unit)
+            EditableViewState.Success(old = Unit, succeeded = Unit),
         ).map { viewState ->
             dynamicTest("given a $viewState when reaction to initial then the action does not run") {
                 val block = mockk<(Unit) -> Unit>()
@@ -239,11 +239,11 @@ class EditableViewStateTest {
         }
 
     @Test
-    fun `given a loading state when reacting to it then the expected action runs`() {
+    fun `given a saving state when reacting to it then the expected action runs`() {
         val block = mockk<(Unit, Unit) -> Unit>()
         justRun { block(Unit, Unit) }
-        val viewState = EditableViewState.Loading(current = Unit, target = Unit)
-        viewState.onLoading(block)
+        val viewState = EditableViewState.Saving(current = Unit, target = Unit)
+        viewState.onSaving(block)
         verify { block(Unit, Unit) }
     }
 
@@ -254,14 +254,14 @@ class EditableViewStateTest {
             EditableViewState.Failure(
                 current = Unit,
                 failed = Unit,
-                exception = RuntimeException()
+                exception = RuntimeException(),
             ),
-            EditableViewState.Success(old = Unit, succeeded = Unit)
+            EditableViewState.Success(old = Unit, succeeded = Unit),
         ).map { viewState ->
             dynamicTest("given a $viewState when reaction to loading then the action does not run") {
                 val block = mockk<(Unit, Unit) -> Unit>()
                 justRun { block(Unit, Unit) }
-                viewState.onLoading(block)
+                viewState.onSaving(block)
                 verify(exactly = 0) { block(Unit, Unit) }
             }
         }
@@ -279,12 +279,12 @@ class EditableViewStateTest {
     fun `given a not success state when reaction to success then the action does not run`() =
         listOf(
             EditableViewState.Initial(Unit),
-            EditableViewState.Loading(current = Unit, target = Unit),
+            EditableViewState.Saving(current = Unit, target = Unit),
             EditableViewState.Failure(
                 current = Unit,
                 failed = Unit,
-                exception = RuntimeException()
-            )
+                exception = RuntimeException(),
+            ),
         ).map { viewState ->
             dynamicTest("given a $viewState when reaction to success then the action does not run") {
                 val block = mockk<(Unit, Unit) -> Unit>()
@@ -302,7 +302,7 @@ class EditableViewStateTest {
         val viewState = EditableViewState.Failure(
             current = Unit,
             failed = Unit,
-            exception = exception
+            exception = exception,
         )
         viewState.onFailure(block)
         verify { block(Unit, Unit, exception) }
@@ -312,8 +312,8 @@ class EditableViewStateTest {
     fun `given a not failure state when reaction to failure then the action does not run`() =
         listOf(
             EditableViewState.Initial(Unit),
-            EditableViewState.Loading(current = Unit, target = Unit),
-            EditableViewState.Success(old = Unit, succeeded = Unit)
+            EditableViewState.Saving(current = Unit, target = Unit),
+            EditableViewState.Success(old = Unit, succeeded = Unit),
         ).map { viewState ->
             dynamicTest("given a $viewState when reaction to failure then the action does not run") {
                 val block = mockk<(Unit, Unit, Throwable) -> Unit>()


### PR DESCRIPTION
This commit renames the `Loading` state and related functions in `EditableViewState` to `Saving`. This change more accurately reflects the state's purpose, which is to indicate that data is currently being saved or updated, not just loaded.