### PR TITLE
Add `map` and `fold` methods to `LoadableViewState`

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,82 @@ val state = LoadableViewState.Success(Unit)
 state.exceptionOrThrow() // Throws IllegalStateException
 ```
 
+#### `map(block: (value: Value) -> NewValue)`
+
+Maps the value of the `LoadableViewState` to a new value of type `NewValue`.
+
+```kotlin
+val state = LoadableViewState.Success("value")
+val newState = state.map { it.length }
+print(newState)
+```
+
+```kotlin
+val state = LoadableViewState.Initial
+val newState = state.map { it.length }
+print(newState)
+```
+
+```kotlin
+val state = LoadableViewState.Loading
+val newState = state.map { it.length }
+print(newState)
+```
+
+```kotlin
+val state = LoadableViewState.Failure(RuntimeException())
+val newState = state.map { it.length }
+print(newState)
+```
+
+#### `fold(onInitial: () -> NewValue, onLoading: () -> NewValue, onSuccess: (value: Value) -> NewValue, onFailure: (throwable: Throwable) -> NewValue)`
+
+Folds the `LoadableViewState` into a new value of type `NewValue`.
+
+```kotlin
+val state = LoadableViewState.Initial
+val result = state.fold(
+    onInitial = { "Initial state" },
+    onLoading = { "Loading state" },
+    onSuccess = { value -> "Success state with value: $value" },
+    onFailure = { throwable -> "Failure state with exception: ${throwable.message}" }
+)
+print(result)
+```
+
+```kotlin
+val state = LoadableViewState.Loading
+val result = state.fold(
+    onInitial = { "Initial state" },
+    onLoading = { "Loading state" },
+    onSuccess = { value -> "Success state with value: $value" },
+    onFailure = { throwable -> "Failure state with exception: ${throwable.message}" }
+)
+print(result)
+```
+
+```kotlin
+val state = LoadableViewState.Success("value")
+val result = state.fold(
+    onInitial = { "Initial state" },
+    onLoading = { "Loading state" },
+    onSuccess = { value -> "Success state with value: $value" },
+    onFailure = { throwable -> "Failure state with exception: ${throwable.message}" }
+)
+print(result)
+```
+
+```kotlin
+val state = LoadableViewState.Failure(RuntimeException("Error message"))
+val result = state.fold(
+    onInitial = { "Initial state" },
+    onLoading = { "Loading state" },
+    onSuccess = { value -> "Success state with value: $value" },
+    onFailure = { throwable -> "Failure state with exception: ${throwable.message}" }
+)
+print(result)
+```
+
 ### `EditableViewState<Value>`
 
 Represents the different states involved in editing data of type Value.

--- a/viewing-state/src/main/java/com/felipearpa/ui/state/LoadableViewState.kt
+++ b/viewing-state/src/main/java/com/felipearpa/ui/state/LoadableViewState.kt
@@ -202,3 +202,45 @@ fun <Value : Any> LoadableViewState<Value>.exceptionOrThrow(): Throwable {
         return this.invoke()
     throw IllegalStateException("Expected exception in Failure state but not found")
 }
+
+/**
+ * Maps the value of the [LoadableViewState] to a new value of type [NewValue].
+ *
+ * @param Value The type of data that the view loads.
+ * @param NewValue The type of data that the view loads.
+ * @param block The function to apply to the value.
+ * @return A new [LoadableViewState] with the mapped value.
+ */
+inline fun <Value : Any, NewValue : Any> LoadableViewState<Value>.map(block: (value: Value) -> NewValue): LoadableViewState<NewValue> {
+    return when (this) {
+        LoadableViewState.Initial -> LoadableViewState.Initial
+        LoadableViewState.Loading -> LoadableViewState.Loading
+        is LoadableViewState.Success -> LoadableViewState.Success(block(value))
+        is LoadableViewState.Failure -> LoadableViewState.Failure(exception)
+    }
+}
+
+/**
+ * Folds the [LoadableViewState] into a new value of type [NewValue].
+ *
+ * @param Value The type of data that the view loads.
+ * @param NewValue The type of data that the view loads.
+ * @param onInitial The function to apply to the initial state.
+ * @param onLoading The function to apply to the loading state.
+ * @param onSuccess The function to apply to the success state.
+ * @param onFailure The function to apply to the failure state.
+ * @return A new value of type [NewValue].
+ */
+inline fun <Value : Any, NewValue> LoadableViewState<Value>.fold(
+    onInitial: () -> NewValue,
+    onLoading: () -> NewValue,
+    onSuccess: (value: Value) -> NewValue,
+    onFailure: (throwable: Throwable) -> NewValue,
+): NewValue {
+    return when (this) {
+        LoadableViewState.Initial -> onInitial()
+        LoadableViewState.Loading -> onLoading()
+        is LoadableViewState.Success -> onSuccess(value)
+        is LoadableViewState.Failure -> onFailure(exception)
+    }
+}


### PR DESCRIPTION
This commit introduces the `map` and `fold` methods to the `LoadableViewState` class to enhance state transformation and handling, respectively.