### PR TITLE
Introduce `SavableViewState`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # viewing-state-android
 
-The **viewing-state-android** package provides classes like `LoadableViewState` and
-`EditableViewState` to handle common view state transitions.
+The **viewing-state-android** package provides classes like `LoadableViewState`, 
+`SavableViewState`, and `EditableViewState` to handle common view state transitions.
 `LoadableViewState` manages four states: initial, loading, success, and failure,
+`SavableViewState` manages four states: initial, saving, success, and failure,
 while `EditableViewState` extends this functionality allowing granular control over state changes.
 
 ## Why
@@ -500,6 +501,246 @@ val result = state.fold(
     onFailure = { throwable -> "Failure state with exception: ${throwable.message}" }
 )
 print(result)
+```
+
+### `SavableViewState<Value>`
+
+Represents the different states involved in saving data of type Value.
+
+#### `Initial`
+
+Represents the initial state of the view, before any data has been saved.
+
+```kotlin
+val initialState = SavableViewState.Initial
+```
+
+#### `Saving<Value>`
+
+Represents the saving state of the view, indicating that data is currently being stored or processed.
+
+```kotlin
+val savingState = SavableViewState.Saving("value")
+```
+
+#### `Success`
+
+Represents the successful state of saving data.
+
+```kotlin
+val successState = SavableViewState.Success
+```
+
+#### `Failure`
+
+Represents the failure state of the view, containing an exception.
+
+```kotlin
+val failureState = SavableViewState.Failure(RuntimeException())
+```
+
+#### `isInitial()`
+
+Checks if the current state is `SavableViewState.Initial`.
+
+```kotlin
+val state = SavableViewState.Initial
+state.isInitial() // Output: true
+```
+
+#### `isSaving()`
+
+Checks if the current state is `SavableViewState.Saving`.
+
+```kotlin
+val state = SavableViewState.Saving("value")
+state.isSaving() // Output: true
+```
+
+#### `isSuccess()`
+
+Checks if the current state is `SavableViewState.Success`.
+
+```kotlin
+val state = SavableViewState.Success
+state.isSuccess() // Output: true
+```
+
+#### `isFailure()`
+
+Checks if the current state is `SavableViewState.Failure`.
+
+```kotlin
+val state = SavableViewState.Failure(RuntimeException())
+state.isFailure() // Output: true
+```
+
+#### `onInitial(block: () -> Unit)`
+
+Executes the given `block` if the current state is `SavableViewState.Initial`.
+
+```kotlin
+val state = SavableViewState.Initial
+state.onInitial { println("Initial state reached") } // Output: Initial state reached
+```
+
+#### `onSaving(block: (Value) -> Unit)`
+
+Executes the given `block` if the current state is `SavableViewState.Saving`.
+
+```kotlin
+val state = SavableViewState.Saving("value")
+state.onSaving { value -> println("Saving state reached with value: $value") } // Output: Saving state reached with value: value
+```
+
+#### `onSuccess(block: () -> Unit)`
+
+Executes the given `block` if the current state is `SavableViewState.Success`.
+
+```kotlin
+val state = SavableViewState.Success
+state.onSuccess { println("Success state reached") } // Output: Success state reached
+```
+
+#### `onFailure(block: (throwable: Throwable) -> Unit)`
+
+Executes the given `block` if the current state is `SavableViewState.Failure`.
+
+```kotlin
+val state = SavableViewState.Failure(RuntimeException())
+state.onFailure { throwable -> println("Failure state reached with exception: ${throwable.message}") } // Output: Failure state reached with exception: null
+```
+
+#### `valueOrNull()`
+
+Returns the value if the current state is `SavableViewState.Saving`, or `null` otherwise.
+
+```kotlin
+val state = SavableViewState.Saving("value")
+state.valueOrNull() // Output: value
+```
+
+```kotlin
+val state = SavableViewState.Failure(RuntimeException())
+state.valueOrNull() // Output: null
+```
+
+#### `valueOrThrow()`
+
+Returns the value if the current state is `SavableViewState.Saving`, or throws an `IllegalStateException` otherwise.
+
+```kotlin
+val state = SavableViewState.Saving("value")
+state.valueOrThrow() // Output: value
+```
+
+```kotlin
+val state = SavableViewState.Failure(RuntimeException())
+state.valueOrThrow() // Throws IllegalStateException
+```
+
+#### `exceptionOrNull()`
+
+Returns the exception if the current state is `SavableViewState.Failure`, or `null` otherwise.
+
+```kotlin
+val state = SavableViewState.Failure(RuntimeException())
+state.exceptionOrNull() // Output: RuntimeException
+```
+
+```kotlin
+val state = SavableViewState.Success
+state.exceptionOrNull() // Output: null
+```
+
+#### `exceptionOrThrow()`
+
+Returns the exception if the current state is `SavableViewState.Failure`, or throws an `IllegalStateException` otherwise.
+
+```kotlin
+val state = SavableViewState.Failure(RuntimeException())
+state.exceptionOrThrow() // Output: RuntimeException
+```
+
+```kotlin
+val state = SavableViewState.Success
+state.exceptionOrThrow() // Throws IllegalStateException
+```
+
+#### `map(block: (value: Value) -> NewValue)`
+
+Maps the value of the `SavableViewState` to a new value of type `NewValue`.
+
+```kotlin
+val state = SavableViewState.Saving("value")
+val newState = state.map { it.length }
+print(newState) // Output: Saving(value=5)
+```
+
+```kotlin
+val state = SavableViewState.Initial
+val newState = state.map { it.length }
+print(newState) // Output: Initial
+```
+
+```kotlin
+val state = SavableViewState.Success
+val newState = state.map { it.length }
+print(newState) // Output: Success
+```
+
+```kotlin
+val state = SavableViewState.Failure(RuntimeException())
+val newState = state.map { it.length }
+print(newState) // Output: Failure(exception=java.lang.RuntimeException)
+```
+
+#### `fold(onInitial: () -> NewValue, onSaving: (value: Value) -> NewValue, onSuccess: () -> NewValue, onFailure: (throwable: Throwable) -> NewValue)`
+
+Folds the `SavableViewState` into a new value of type `NewValue`.
+
+```kotlin
+val state = SavableViewState.Initial
+val result = state.fold(
+    onInitial = { "Initial state" },
+    onSaving = { value -> "Saving state with value: $value" },
+    onSuccess = { "Success state" },
+    onFailure = { throwable -> "Failure state with exception: ${throwable.message}" }
+)
+print(result) // Output: Initial state
+```
+
+```kotlin
+val state = SavableViewState.Saving("value")
+val result = state.fold(
+    onInitial = { "Initial state" },
+    onSaving = { value -> "Saving state with value: $value" },
+    onSuccess = { "Success state" },
+    onFailure = { throwable -> "Failure state with exception: ${throwable.message}" }
+)
+print(result) // Output: Saving state with value: value
+```
+
+```kotlin
+val state = SavableViewState.Success
+val result = state.fold(
+    onInitial = { "Initial state" },
+    onSaving = { value -> "Saving state with value: $value" },
+    onSuccess = { "Success state" },
+    onFailure = { throwable -> "Failure state with exception: ${throwable.message}" }
+)
+print(result) // Output: Success state
+```
+
+```kotlin
+val state = SavableViewState.Failure(RuntimeException("Error message"))
+val result = state.fold(
+    onInitial = { "Initial state" },
+    onSaving = { value -> "Saving state with value: $value" },
+    onSuccess = { "Success state" },
+    onFailure = { throwable -> "Failure state with exception: ${throwable.message}" }
+)
+print(result) // Output: Failure state with exception: Error message
 ```
 
 ### `EditableViewState<Value>`

--- a/viewing-state/src/main/java/com/felipearpa/ui/state/SavableViewState.kt
+++ b/viewing-state/src/main/java/com/felipearpa/ui/state/SavableViewState.kt
@@ -1,0 +1,246 @@
+package com.felipearpa.ui.state
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+/**
+ * Represents the different states of a view that saves data.
+ *
+ * @param Value The type of data that the view saves.
+ */
+sealed class SavableViewState<out Value : Any> {
+    /**
+     * Represents the initial state of the view, before any data has been saved.
+     */
+    data object Initial : SavableViewState<Nothing>()
+
+    /**
+     * Represents the saving state of the view, indicating that data is currently being stored or processed.
+     *
+     * @param Value The type of data that is being saved.
+     * @property value The data that is being saved.
+     */
+    data class Saving<Value : Any>(val value: Value) : SavableViewState<Value>() {
+        operator fun invoke(): Value = value
+    }
+
+    /**
+     * Represents the successful state of saving data.
+     */
+    data object Success : SavableViewState<Nothing>()
+
+    /**
+     * Represents the failure state of the view, containing an exception.
+     *
+     * @property exception The throwable that caused the failure.
+     */
+    data class Failure(val exception: Throwable) : SavableViewState<Nothing>() {
+        operator fun invoke(): Throwable = exception
+    }
+}
+
+/**
+ * Checks if the current state is [SavableViewState.Initial].
+ *
+ * @param Value The type of data that the view saves.
+ * @return `true` if the state is [SavableViewState.Initial], `false` otherwise.
+ */
+@OptIn(ExperimentalContracts::class)
+fun <Value : Any> SavableViewState<Value>.isInitial(): Boolean {
+    contract {
+        returns(true) implies (this@isInitial is SavableViewState.Initial)
+    }
+
+    return this is SavableViewState.Initial
+}
+
+/**
+ * Checks if the current state is [SavableViewState.Saving].
+ *
+ * @param Value The type of data that the view saves.
+ * @return `true` if the state is [SavableViewState.Saving], `false` otherwise.
+ */
+@OptIn(ExperimentalContracts::class)
+fun <Value : Any> SavableViewState<Value>.isSaving(): Boolean {
+    contract {
+        returns(true) implies (this@isSaving is SavableViewState.Saving)
+    }
+
+    return this is SavableViewState.Saving
+}
+
+/**
+ * Checks if the current state is [SavableViewState.Success].
+ *
+ * @param Value The type of data that the view saves.
+ * @return `true` if the state is [SavableViewState.Success], `false` otherwise.
+ */
+@OptIn(ExperimentalContracts::class)
+fun <Value : Any> SavableViewState<Value>.isSuccess(): Boolean {
+    contract {
+        returns(true) implies (this@isSuccess is SavableViewState.Success)
+    }
+
+    return this is SavableViewState.Success
+}
+
+/**
+ * Checks if the current state is [SavableViewState.Failure].
+ *
+ * @param Value The type of data that the view saves.
+ * @return `true` if the state is [SavableViewState.Failure], `false` otherwise.
+ */
+@OptIn(ExperimentalContracts::class)
+fun <Value : Any> SavableViewState<Value>.isFailure(): Boolean {
+    contract {
+        returns(true) implies (this@isFailure is SavableViewState.Failure)
+    }
+
+    return this is SavableViewState.Failure
+}
+
+/**
+ * Executes the given [block] if the current state is [SavableViewState.Initial].
+ *
+ * @param Value The type of data that the view saves.
+ * @param block The block of code to execute.
+ * @return The original [SavableViewState] instance.
+ */
+inline fun <Value : Any> SavableViewState<Value>.onInitial(block: () -> Unit): SavableViewState<Value> {
+    if (isInitial()) {
+        block()
+    }
+    return this
+}
+
+/**
+ * Executes the given [block] if the current state is [SavableViewState.Saving].
+ *
+ * @param Value The type of data that the view saves.
+ * @param block The block of code to execute.
+ * @return The original [SavableViewState] instance.
+ */
+inline fun <Value : Any> SavableViewState<Value>.onSaving(block: (Value) -> Unit): SavableViewState<Value> {
+    if (isSaving()) {
+        block(this())
+    }
+    return this
+}
+
+/**
+ * Executes the given [block] if the current state is [SavableViewState.Success].
+ *
+ * @param Value The type of data that the view saves.
+ * @param block The block of code to execute.
+ * @return The original [SavableViewState] instance.
+ */
+inline fun <Value : Any> SavableViewState<Value>.onSuccess(block: () -> Unit): SavableViewState<Value> {
+    if (isSuccess()) {
+        block()
+    }
+    return this
+}
+
+/**
+ * Executes the given [block] if the current state is [SavableViewState.Failure].
+ *
+ * @param Value The type of data that the view saves.
+ * @param block The block of code to execute.
+ * @return The original [SavableViewState] instance.
+ */
+inline fun <Value : Any> SavableViewState<Value>.onFailure(block: (throwable: Throwable) -> Unit): SavableViewState<Value> {
+    if (isFailure()) {
+        block(this())
+    }
+    return this
+}
+
+/**
+ * Returns the value if the current state is [SavableViewState.Saving], or `null` otherwise.
+ *
+ * @param Value The type of data that the view saves.
+ * @return The value if the state is [SavableViewState.Saving], `null` otherwise.
+ */
+fun <Value : Any> SavableViewState<Value>.valueOrNull(): Value? {
+    if (isSaving())
+        return this()
+    return null
+}
+
+/**
+ * Returns the value if the current state is [SavableViewState.Saving], or throws an [IllegalStateException] otherwise.
+ *
+ * @param Value The type of data that the view saves.
+ * @return The value if the state is [SavableViewState.Saving], or throws an [IllegalStateException] otherwise.
+ */
+fun <Value : Any> SavableViewState<Value>.valueOrThrow(): Value {
+    if (isSaving())
+        return this()
+    throw IllegalStateException("Expected value in Saving state but not found")
+}
+
+/**
+ * Returns the exception if the current state is [SavableViewState.Failure], or `null` otherwise.
+ *
+ * @param Value The type of data that the view saves.
+ * @return The exception if the state is [SavableViewState.Failure], `null` otherwise.
+ */
+fun <Value : Any> SavableViewState<Value>.exceptionOrNull(): Throwable? {
+    if (isFailure())
+        return this()
+    return null
+}
+
+/**
+ * Returns the exception if the current state is [SavableViewState.Failure], or throws an [IllegalStateException] otherwise.
+ *
+ * @param Value The type of data that the view saves.
+ * @return The exception if the state is [SavableViewState.Failure], or throws an [IllegalStateException] otherwise.
+ */
+fun <Value : Any> SavableViewState<Value>.exceptionOrThrow(): Throwable {
+    if (isFailure())
+        return this()
+    throw IllegalStateException("Expected exception in Failure state but not found")
+}
+
+/**
+ * Maps the value of the [SavableViewState] to a new value of type [NewValue].
+ *
+ * @param Value The type of data that the view saves.
+ * @param NewValue The type of data that the view saves.
+ * @param block The function to apply to the value.
+ * @return A new [SavableViewState] with the mapped value.
+ */
+inline fun <Value : Any, NewValue : Any> SavableViewState<Value>.map(block: (value: Value) -> NewValue): SavableViewState<NewValue> {
+    return when (this) {
+        SavableViewState.Initial -> SavableViewState.Initial
+        is SavableViewState.Saving -> SavableViewState.Saving(block(value))
+        SavableViewState.Success -> SavableViewState.Success
+        is SavableViewState.Failure -> SavableViewState.Failure(exception)
+    }
+}
+
+/**
+ * Folds the [SavableViewState] into a new value of type [NewValue].
+ *
+ * @param Value The type of data that the view saves.
+ * @param NewValue The type of data that the view saves.
+ * @param onInitial The function to apply to the initial state.
+ * @param onSaving The function to apply to the saving state.
+ * @param onSuccess The function to apply to the success state.
+ * @param onFailure The function to apply to the failure state.
+ * @return A new value of type [NewValue].
+ */
+inline fun <Value : Any, NewValue> SavableViewState<Value>.fold(
+    onInitial: () -> NewValue,
+    onSaving: (Value) -> NewValue,
+    onSuccess: () -> NewValue,
+    onFailure: (throwable: Throwable) -> NewValue,
+): NewValue {
+    return when (this) {
+        SavableViewState.Initial -> onInitial()
+        is SavableViewState.Saving -> onSaving(value)
+        SavableViewState.Success -> onSuccess()
+        is SavableViewState.Failure -> onFailure(exception)
+    }
+}

--- a/viewing-state/src/test/java/com/felipearpa/ui/state/SavableViewStateTest.kt
+++ b/viewing-state/src/test/java/com/felipearpa/ui/state/SavableViewStateTest.kt
@@ -1,0 +1,401 @@
+package com.felipearpa.ui.state
+
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+
+class SavableViewStateTest {
+    @Test
+    fun `given an initial state when checked if initial then initial is confirmed`() {
+        val viewState: SavableViewState<String> = SavableViewState.Initial
+        val isInitial = viewState.isInitial()
+        isInitial.shouldBeTrue()
+    }
+
+    @TestFactory
+    fun `given a not initial state when checked if initial then initial is not confirmed`() =
+        listOf(
+            SavableViewState.Saving(savingValue),
+            SavableViewState.Failure(failureException),
+            SavableViewState.Success,
+        ).map { viewState ->
+            dynamicTest("given a state of $viewState when checked if initial then initial is not confirmed") {
+                val isInitial = viewState.isInitial()
+                isInitial.shouldBeFalse()
+            }
+        }
+
+    @Test
+    fun `given a saving state when checked if saving then saving is confirmed`() {
+        val viewState: SavableViewState<String> = SavableViewState.Saving(savingValue)
+        val isSaving = viewState.isSaving()
+        isSaving.shouldBeTrue()
+    }
+
+    @TestFactory
+    fun `given a not saving state when checked if saving then saving is not confirmed`() =
+        listOf<SavableViewState<String>>(
+            SavableViewState.Initial,
+            SavableViewState.Failure(failureException),
+            SavableViewState.Success,
+        ).map { viewState ->
+            dynamicTest("given a state of $viewState when checked if saving then saving is not confirmed") {
+                val isSaving = viewState.isSaving()
+                isSaving.shouldBeFalse()
+            }
+        }
+
+    @Test
+    fun `given a failure state when checked if failure then failure is confirmed`() {
+        val viewState: SavableViewState<String> = SavableViewState.Failure(failureException)
+        val isFailure = viewState.isFailure()
+        isFailure.shouldBeTrue()
+    }
+
+    @TestFactory
+    fun `given a not failure state when checked if failure then failure is not confirmed`() =
+        listOf(
+            SavableViewState.Initial,
+            SavableViewState.Saving(savingValue),
+            SavableViewState.Success,
+        ).map { viewState ->
+            dynamicTest("given a state of $viewState when checked if failure then failure is not confirmed") {
+                val isFailure = viewState.isFailure()
+                isFailure.shouldBeFalse()
+            }
+        }
+
+    @Test
+    fun `given a success state when checked if success then success is confirmed`() {
+        val viewState: SavableViewState<String> = SavableViewState.Success
+        val isSuccess = viewState.isSuccess()
+        isSuccess.shouldBeTrue()
+    }
+
+    @TestFactory
+    fun `given a not success state when checked if success then success is not confirmed`() =
+        listOf(
+            SavableViewState.Initial,
+            SavableViewState.Saving(savingValue),
+            SavableViewState.Failure(failureException),
+        ).map { viewState ->
+            dynamicTest("given a state of $viewState when checked if success then success is not confirmed") {
+                val isSuccess = viewState.isSuccess()
+                isSuccess.shouldBeFalse()
+            }
+        }
+
+    @Test
+    fun `given an initial state when checked with isInitial then state is smart cast to Initial`() {
+        val state: SavableViewState<String> = SavableViewState.Initial
+
+        if (state.isInitial()) {
+            // If it compiles, the contract is working correctly
+            val castedState: SavableViewState.Initial = state
+            castedState.shouldBeInstanceOf<SavableViewState.Initial>()
+        }
+    }
+
+    @Test
+    fun `given a saving state when checked with isSaving then state is smart cast to Saving`() {
+        val state: SavableViewState<String> = SavableViewState.Saving(savingValue)
+
+        if (state.isSaving()) {
+            // If it compiles, the contract is working correctly
+            val castedState: SavableViewState.Saving<String> = state
+            castedState.shouldBeInstanceOf<SavableViewState.Saving<String>>()
+        }
+    }
+
+    @Test
+    fun `given a success state when checked with isSuccess then state is smart cast to Success`() {
+        val state: SavableViewState<String> = SavableViewState.Success
+
+        if (state.isSuccess()) {
+            // If it compiles, the contract is working correctly
+            val castedState: SavableViewState.Success = state
+            castedState.shouldBeInstanceOf<SavableViewState.Success>()
+        }
+    }
+
+    @Test
+    fun `given a failure state when checked with isFailure then state is smart cast to Failure`() {
+        val state: SavableViewState<String> = SavableViewState.Failure(failureException)
+
+        if (state.isFailure()) {
+            // If it compiles, the contract is working correctly
+            val castedState: SavableViewState.Failure = state
+            castedState.shouldBeInstanceOf<SavableViewState.Failure>()
+        }
+    }
+
+    @Test
+    fun `given a failure when checked for exception then the exception is found`() {
+        val viewState: SavableViewState<String> = SavableViewState.Failure(failureException)
+        val exception = viewState.exceptionOrNull()
+        exception.shouldBeInstanceOf<RuntimeException>()
+    }
+
+    @TestFactory
+    fun `given a no failure when checked for exception then the exception is not found`() =
+        listOf(
+            SavableViewState.Initial,
+            SavableViewState.Saving(savingValue),
+            SavableViewState.Success,
+        ).map { viewState ->
+            dynamicTest("given a $viewState when checked for exception then the exception is not found") {
+                val exception = viewState.exceptionOrNull()
+                exception.shouldBeNull()
+            }
+        }
+
+    @Test
+    fun `given a failure when checked for exception then the exception is not thrown`() {
+        val viewState: SavableViewState<String> = SavableViewState.Failure(failureException)
+        val exception = viewState.exceptionOrThrow()
+        exception.shouldBeInstanceOf<RuntimeException>()
+        exception shouldBe failureException
+    }
+
+    @TestFactory
+    fun `given a no failure when checked for exception then an exception is thrown`() =
+        listOf(
+            SavableViewState.Initial,
+            SavableViewState.Saving(savingValue),
+            SavableViewState.Success,
+        ).map { viewState ->
+            dynamicTest("given a $viewState when checked for exception then the exception is not thrown") {
+                shouldThrowExactly<IllegalStateException> {
+                    viewState.exceptionOrThrow()
+                }
+            }
+        }
+
+    @Test
+    fun `given a saving when checked for value then the value is found`() {
+        val viewState: SavableViewState<String> = SavableViewState.Saving(savingValue)
+        val value = viewState.valueOrNull()
+        value shouldBe savingValue
+    }
+
+    @TestFactory
+    fun `given a no saving when checked for value then the value is not found`() =
+        listOf<SavableViewState<String>>(
+            SavableViewState.Initial,
+            SavableViewState.Success,
+            SavableViewState.Failure(failureException),
+        ).map { viewState ->
+            dynamicTest("given a $viewState when checked for value then the value is not found") {
+                val value = viewState.valueOrNull()
+                value.shouldBeNull()
+            }
+        }
+
+    @Test
+    fun `given a saving when checked for value then the value is not thrown`() {
+        val viewState: SavableViewState<String> = SavableViewState.Saving(savingValue)
+        val value = viewState.valueOrThrow()
+        value shouldBe savingValue
+    }
+
+    @TestFactory
+    fun `given a no saving when checked for value then an exception is thrown`() =
+        listOf<SavableViewState<String>>(
+            SavableViewState.Initial,
+            SavableViewState.Success,
+            SavableViewState.Failure(failureException),
+        ).map { viewState ->
+            dynamicTest("given a $viewState when checked for value then the value is not thrown") {
+                shouldThrowExactly<IllegalStateException> {
+                    viewState.valueOrThrow()
+                }
+            }
+        }
+
+    @Test
+    fun `given an initial state when reacting to it then the expected action runs`() {
+        val block = mockk<() -> Unit>()
+        justRun { block() }
+        val viewState: SavableViewState<String> = SavableViewState.Initial
+        viewState.onInitial(block)
+        verify { block() }
+    }
+
+    @TestFactory
+    fun `given a not initial state when reaction to initial then the action does not run`() =
+        listOf(
+            SavableViewState.Saving(savingValue),
+            SavableViewState.Failure(failureException),
+            SavableViewState.Success,
+        ).map { viewState ->
+            dynamicTest("given a $viewState when reaction to initial then the action does not run") {
+                val block = mockk<() -> Unit>()
+                justRun { block() }
+                viewState.onInitial(block)
+                verify(exactly = 0) { block() }
+            }
+        }
+
+    @Test
+    fun `given a saving state when reacting to it then the expected action runs`() {
+        val block = mockk<(String) -> Unit>()
+        justRun { block(savingValue) }
+        val viewState: SavableViewState<String> = SavableViewState.Saving(savingValue)
+        viewState.onSaving(block)
+        verify { block(savingValue) }
+    }
+
+    @TestFactory
+    fun `given a not saving state when reaction to loading then the action does not run`() =
+        listOf(
+            SavableViewState.Initial,
+            SavableViewState.Failure(failureException),
+            SavableViewState.Success,
+        ).map { viewState ->
+            dynamicTest("given a $viewState when reaction to loading then the action does not run") {
+                val block = mockk<(String) -> Unit>()
+                justRun { block(savingValue) }
+                viewState.onSaving(block)
+                verify(exactly = 0) { block(savingValue) }
+            }
+        }
+
+    @Test
+    fun `given a success state when reacting to it then the expected action runs`() {
+        val block = mockk<() -> Unit>()
+        justRun { block() }
+        val viewState: SavableViewState<String> = SavableViewState.Success
+        viewState.onSuccess(block)
+        verify { block() }
+    }
+
+    @TestFactory
+    fun `given a not success state when reaction to success then the action does not run`() =
+        listOf(
+            SavableViewState.Initial,
+            SavableViewState.Saving(savingValue),
+            SavableViewState.Failure(failureException),
+        ).map { viewState ->
+            dynamicTest("given a $viewState when reaction to success then the action does not run") {
+                val block = mockk<() -> Unit>()
+                justRun { block() }
+                viewState.onSuccess(block)
+                verify(exactly = 0) { block() }
+            }
+        }
+
+    @Test
+    fun `given a failure state when reacting to it then the expected action runs`() {
+        val block = mockk<(throwable: Throwable) -> Unit>()
+        justRun { block(failureException) }
+        val viewState: SavableViewState<String> = SavableViewState.Failure(failureException)
+        viewState.onFailure(block)
+        verify { block(failureException) }
+    }
+
+    @TestFactory
+    fun `given a not failure state when reaction to failure then the action does not run`() =
+        listOf(
+            SavableViewState.Initial,
+            SavableViewState.Saving(savingValue),
+            SavableViewState.Success,
+        ).map { viewState ->
+            dynamicTest("given a $viewState when reaction to failure then the action does not run") {
+                val block = mockk<(throwable: Throwable) -> Unit>()
+                justRun { block(any()) }
+                viewState.onFailure(block)
+                verify(exactly = 0) { block(any()) }
+            }
+        }
+
+    @Test
+    fun `given a saving state when mapping then the state is transformed`() {
+        val block = mockk<(value: String) -> String>()
+        every { block(savingValue) } returns transformSuccessValue
+        val viewState: SavableViewState<String> = SavableViewState.Saving(savingValue)
+        val newState = viewState.map { block(it) }
+        verify { block(savingValue) }
+        newState.shouldBeInstanceOf<SavableViewState.Saving<String>>()
+        newState.value shouldBe transformSuccessValue
+    }
+
+    @TestFactory
+    fun `given a not saving state when mapping then the state is not transformed`() =
+        listOf<SavableViewState<String>>(
+            SavableViewState.Initial,
+            SavableViewState.Success,
+            SavableViewState.Failure(failureException),
+        ).map { viewState ->
+            dynamicTest("given a $viewState when mapping then the expected value is not returned") {
+                val block = mockk<(value: String) -> String>()
+                every { block(savingValue) } returns transformSuccessValue
+                viewState.map { block(it) }
+                verify(exactly = 0) { block(savingValue) }
+            }
+        }
+
+    @Test
+    fun `given an initial state when folding then the expected value is returned`() {
+        val viewState: SavableViewState<String> = SavableViewState.Initial
+        val value = viewState.fold(
+            onInitial = { transformedInitialValue },
+            onSaving = { transformedSavingValue },
+            onSuccess = { transformSuccessValue },
+            onFailure = { transformedFailureValue },
+        )
+        value shouldBe transformedInitialValue
+    }
+
+    @Test
+    fun `given a saving state when folding then the expected value is returned`() {
+        val viewState: SavableViewState<String> = SavableViewState.Saving(savingValue)
+        val value = viewState.fold(
+            onInitial = { transformedInitialValue },
+            onSaving = { transformedSavingValue },
+            onSuccess = { transformSuccessValue },
+            onFailure = { transformedFailureValue },
+        )
+        value shouldBe transformedSavingValue
+    }
+
+    @Test
+    fun `given a success state when folding then the expected value is returned`() {
+        val viewState: SavableViewState<String> = SavableViewState.Success
+        val value = viewState.fold(
+            onInitial = { transformedInitialValue },
+            onSaving = { transformedSavingValue },
+            onSuccess = { transformSuccessValue },
+            onFailure = { transformedFailureValue },
+        )
+        value shouldBe transformSuccessValue
+    }
+
+    @Test
+    fun `given a failure state when folding then the expected value is returned`() {
+        val viewState: SavableViewState<String> = SavableViewState.Failure(failureException)
+        val value = viewState.fold(
+            onInitial = { transformedInitialValue },
+            onSaving = { transformedSavingValue },
+            onSuccess = { transformSuccessValue },
+            onFailure = { transformedFailureValue },
+        )
+        value shouldBe transformedFailureValue
+    }
+}
+
+private const val savingValue = "saving value"
+private const val transformedInitialValue = "transformed initial value"
+private const val transformedSavingValue = "transformed saving value"
+private const val transformSuccessValue = "transformed success value"
+private const val transformedFailureValue = "transformed failure value"
+private val failureException = RuntimeException()


### PR DESCRIPTION
This commit adds the `SavableViewState` class, which manages view states for saving operations (`Initial`, `Saving`, `Success`, and `Failure`).